### PR TITLE
Ensure terminal obeys debug disabling flags

### DIFF
--- a/framework/luaengine/luainterface.h
+++ b/framework/luaengine/luainterface.h
@@ -361,6 +361,8 @@ private:
     int m_totalObjRefs;
     int m_totalFuncRefs;
     int m_globalEnv;
+    int m_originalLoadstringRef;
+    int m_originalLoadRef;
 };
 
 extern LuaInterface g_lua;


### PR DESCRIPTION
## Summary
- add shared helper logic so terminal commands always return "Terminal is disabled on this server" whenever DEF_DEFINITION or GameNoDebug disables execution
- wrap Lua's `loadstring`/`load` to forward to the original implementation when permitted while preserving the functions' references for cleanup

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d589f5d6bc83239186f27554027fa7